### PR TITLE
[POC] Bridge iOS 13 traitCollectionDidChange

### DIFF
--- a/Sources/DarkModeCore/DMTraitCollection.h
+++ b/Sources/DarkModeCore/DMTraitCollection.h
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/DarkModeCore/DMTraitCollection.m
+++ b/Sources/DarkModeCore/DMTraitCollection.m
@@ -10,7 +10,11 @@
 static DMTraitCollection *_currentTraitCollection = nil;
 
 + (DMTraitCollection *)currentTraitCollection {
-  return _currentTraitCollection;
+  if (@available(iOS 13, *)) {
+    return (DMTraitCollection *)UITraitCollection.currentTraitCollection;
+  } else {
+    return _currentTraitCollection;
+  }
 }
 
 + (void)setCurrentTraitCollection:(DMTraitCollection *)currentTraitCollection {

--- a/Sources/DarkModeCore/UIView+DarkModeKit.h
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIView (DarkModeKit) <DMTraitEnvironment>
 
 + (void)dm_swizzleSetBackgroundColor;
++ (void)dm_swizzleTraitCollectionDidChange;
 
 @property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicBackgroundColor;
 @property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicTintColor;

--- a/Sources/DarkModeCore/UIView+DarkModeKit.h
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.h
@@ -3,18 +3,21 @@
 //  Licensed under the MIT License.
 //
 
-#import <UIKit/UIKit.h>
+#import <DarkModeKit/DMTraitCollection.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class DMDynamicColor;
 
-@interface UIView (DarkModeKit)
+@interface UIView (DarkModeKit) <DMTraitEnvironment>
 
 + (void)dm_swizzleSetBackgroundColor;
 
 @property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicBackgroundColor;
 @property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicTintColor;
+
+- (void)dm_updateDynamicColors;
+- (void)dm_updateDynamicImages;
 
 @end
 

--- a/Sources/DarkModeCore/UIView+DarkModeKit.h
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)dm_swizzleSetBackgroundColor;
 
 @property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicBackgroundColor;
+@property (nonatomic, copy, nullable) DMDynamicColor *dm_dynamicTintColor;
 
 @end
 

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -78,11 +78,16 @@ static void dm_traitCollectionDidChange(UIView *self, SEL _cmd, UITraitCollectio
 #pragma mark -
 
 - (void)dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection {
-  for (UIView *subview in self.subviews) {
-    [subview dmTraitCollectionDidChange:previousTraitCollection];
+  if (@available(iOS 13 *)) {
+    // No need to propagate by ourself.
+  } else {
+    for (UIView *subview in self.subviews) {
+      [subview dmTraitCollectionDidChange:previousTraitCollection];
+    }
+    [self setNeedsLayout];
+    [self setNeedsDisplay];
   }
-  [self setNeedsLayout];
-  [self setNeedsDisplay];
+
   [self dm_updateDynamicColors];
   [self dm_updateDynamicImages];
 }

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -33,6 +33,24 @@ static void dm_setBackgroundColor(UIView *self, SEL _cmd, UIColor *color) {
 
 #pragma mark -
 
+static void (*dm_original_traitCollectionDidChange)(UIView *, SEL, UITraitCollection *);
+
+static void dm_traitCollectionDidChange(UIView *self, SEL _cmd, UITraitCollection *previousTraitCollection) {
+  dm_original_traitCollectionDidChange(self, _cmd, previousTraitCollection);
+  [self dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection];
+}
+
++ (void)dm_swizzleTraitCollectionDidChange {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Method method = class_getInstanceMethod(self, @selector(traitCollectionDidChange:));
+    dm_original_traitCollectionDidChange = (void *)method_getImplementation(method);
+    method_setImplementation(method, (IMP)dm_traitCollectionDidChange);
+  });
+}
+
+#pragma mark -
+
 - (DMDynamicColor *)dm_dynamicBackgroundColor {
   return objc_getAssociatedObject(self, _cmd);
 }

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -31,6 +31,8 @@ static void dm_setBackgroundColor(UIView *self, SEL _cmd, UIColor *color) {
   });
 }
 
+#pragma mark -
+
 - (DMDynamicColor *)dm_dynamicBackgroundColor {
   return objc_getAssociatedObject(self, _cmd);
 }
@@ -39,6 +41,19 @@ static void dm_setBackgroundColor(UIView *self, SEL _cmd, UIColor *color) {
   objc_setAssociatedObject(self,
                            @selector(dm_dynamicBackgroundColor),
                            dm_dynamicBackgroundColor,
+                           OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+#pragma mark -
+
+- (DMDynamicColor *)dm_dynamicTintColor {
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setDm_dynamicTintColor:(DMDynamicColor *)dm_dynamicTintColor {
+  objc_setAssociatedObject(self,
+                           @selector(dm_dynamicTintColor),
+                           dm_dynamicTintColor,
                            OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -57,4 +57,29 @@ static void dm_setBackgroundColor(UIView *self, SEL _cmd, UIColor *color) {
                            OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
+#pragma mark -
+
+- (void)dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection {
+  for (UIView *subview in self.subviews) {
+    [subview dmTraitCollectionDidChange:previousTraitCollection];
+  }
+  [self setNeedsLayout];
+  [self setNeedsDisplay];
+  [self dm_updateDynamicColors];
+  [self dm_updateDynamicImages];
+}
+
+- (void)dm_updateDynamicColors {
+  if (self.dm_dynamicBackgroundColor) {
+    self.backgroundColor = self.dm_dynamicBackgroundColor;
+  }
+  if (self.dm_dynamicTintColor) {
+    self.tintColor = self.dm_dynamicTintColor;
+  }
+}
+
+- (void)dm_updateDynamicImages {
+  // For subclasses to override.
+}
+
 @end

--- a/Sources/DarkModeKit/DarkModeManager.swift
+++ b/Sources/DarkModeKit/DarkModeManager.swift
@@ -13,6 +13,9 @@ public final class DarkModeManager: NSObject {
     UIView.swizzleSetTintColorOnce
     UITextField.swizzleTextFieldWillMoveToWindowOnce
     UILabel.swizzleDidMoveToWindowOnce
+    if #available(iOS 13, *) {
+      UIView.dm_swizzleTraitCollectionDidChange()
+    }
 
     // Images
     UIImageView.swizzleSetImageOnce

--- a/Sources/DarkModeKit/Extensions/UIButton+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIButton+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UIButton {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     [UIControl.State.normal, .highlighted, .disabled, .selected, .focused].forEach { state in

--- a/Sources/DarkModeKit/Extensions/UIImageView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIImageView+DarkModeKit.swift
@@ -37,7 +37,7 @@ extension UIImageView {
     return dm_init(image: image)
   }
 
-  override func dm_updateDynamicImages() {
+  open override func dm_updateDynamicImages() {
     super.dm_updateDynamicImages()
 
     if let dynamicImage = dm_dynamicImage {

--- a/Sources/DarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UINavigationBar {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
     
     if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UIPageControl {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
     
     if let dynamicPageIndicatorTintColor = pageIndicatorTintColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UIProgressView {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     if let dynamicProgressTintColor = progressTintColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UIScrollView {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     indicatorStyle = {

--- a/Sources/DarkModeKit/Extensions/UISlider+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UISlider+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UISlider {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     if let dynamicMinimumTrackTintColor = minimumTrackTintColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UITabBar+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UITabBar+DarkModeKit.swift
@@ -13,7 +13,7 @@ extension UITabBar {
     items?.forEach { $0.dmTraitCollectionDidChange(previousTraitCollection) }
   }
 
-  override func dm_updateDynamicImages() {
+  open override func dm_updateDynamicImages() {
     super.dm_updateDynamicImages()
     items?.forEach { $0._updateDynamicImages() }
   }

--- a/Sources/DarkModeKit/Extensions/UITableView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UITableView+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UITableView {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
     
     if let dynamicSectionIndexColor = sectionIndexColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UITextField+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UITextField+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UITextField {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     if let dynamicTextColor = textColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UITextView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UITextView+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UITextView {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
     
     keyboardAppearance = {

--- a/Sources/DarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
@@ -8,7 +8,7 @@ import DarkModeCore
 #endif
 
 extension UIToolbar {
-  override func dm_updateDynamicColors() {
+  open override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()
 
     if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {

--- a/Sources/DarkModeKit/Extensions/UIView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIView+DarkModeKit.swift
@@ -47,20 +47,11 @@ extension UIView {
 }
 
 extension UIView {
-  private struct Constants {
-    static var dynamicTintColorKey = "dynamicTintColorKey"
-  }
-
   static let swizzleSetTintColorOnce: Void = {
     if !dm_swizzleInstanceMethod(#selector(setter: tintColor), to: #selector(dm_setTintColor)) {
       assertionFailure(DarkModeManager.messageForSwizzlingFailed(class: UIView.self, selector: #selector(setter: tintColor)))
     }
   }()
-
-  private var dm_dynamicTintColor: DynamicColor? {
-    get { return objc_getAssociatedObject(self, &Constants.dynamicTintColorKey) as? DynamicColor }
-    set { objc_setAssociatedObject(self, &Constants.dynamicTintColorKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC) }
-  }
 
   @objc private dynamic func dm_setTintColor(_ color: UIColor) {
     dm_dynamicTintColor = color as? DynamicColor

--- a/Sources/DarkModeKit/Extensions/UIView+DarkModeKit.swift
+++ b/Sources/DarkModeKit/Extensions/UIView+DarkModeKit.swift
@@ -7,29 +7,6 @@
 import DarkModeCore
 #endif
 
-extension UIView: DMTraitEnvironment {
-  open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
-    subviews.forEach { $0.dmTraitCollectionDidChange(previousTraitCollection) }
-    setNeedsLayout()
-    setNeedsDisplay()
-    dm_updateDynamicColors()
-    dm_updateDynamicImages()
-  }
-
-  @objc func dm_updateDynamicColors() {
-    if let dynamicBackgroundColor = dm_dynamicBackgroundColor {
-      backgroundColor = dynamicBackgroundColor
-    }
-    if let dynamicTintColor = dm_dynamicTintColor {
-      tintColor = dynamicTintColor
-    }
-  }
-
-  @objc func dm_updateDynamicImages() {
-    // For subclasses to override.
-  }
-}
-
 extension UIView {
   static let swizzleWillMoveToWindowOnce: Void = {
     if !dm_swizzleInstanceMethod(#selector(willMove(toWindow:)), to: #selector(dm_willMove(toWindow:))) {


### PR DESCRIPTION
This PR is a POC for bridging `traitCollectionDidChange` in iOS 13.

How it works:
- Return `UITraitCollection.current` in `DMTraitCollection.current`. Since `DMTraitCollection`'s API is identical to `UITraitCollection`, method caller will not notice any difference
- Add a call to `dmTraitCollectionDidChange` in the end of `traitCollectionDidChange`

Why:
- We encountered a problem with multi-window support in iPadOS 13