### PR TITLE
Fix UIScrollView indicator display in dark mode

### DIFF
--- a/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
@@ -13,7 +13,7 @@ extension UIScrollView {
 
     indicatorStyle = {
       if DMTraitCollection.current.userInterfaceStyle == .dark {
-        return .black
+        return .white
       }
       else {
         return .default


### PR DESCRIPTION
Use .white indicator style in UIScrollView when in dark mode

According to [https://developer.apple.com/documentation/uikit/uiscrollview/indicatorstyle](url), UIScrollViewIndicatorStyleWhite is `a style of indicator is white and smaller than the default style. This style is good against a black content background`, thus should be used in dark mode.