### PR TITLE
Fix importing via spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ])
     ],
     targets: [
-        .target(name: "DarkModeCore"),
+        .target(name: "DarkModeCore", cSettings: [.define("SWIFT_PACKAGE")]),
         .target(name: "FluentDarkModeKit", dependencies: ["DarkModeCore"]),
         .testTarget(name: "FluentDarkModeKitTests", dependencies: ["FluentDarkModeKit"]),
     ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ github "microsoft/FluentDarkModeKit"
 
 Click "Files -> Swift Package Manager -> Add Package Dependency..." in Xcode's menu and search "https://github.com/microsoft/FluentDarkModeKit"
 
+Since Xcode uses its own tools to handle swifft packages, git-lfs might not be picked up if it is installed via Homebrew. Run the following command to create a symbolic link if Xcode fails to fetch the package:
+
+```
+ln -s /usr/local/bin/git-lfs $(xcode-select -p)/usr/bin/git-lfs
+```
+
 ### CocoaPods
 
 To integrate FluentDarkModeKit into your Xcode project using CocoaPods, specify it in your `Podfile`:

--- a/Sources/DarkModeCore/UIColor+DarkModeKit.h
+++ b/Sources/DarkModeCore/UIColor+DarkModeKit.h
@@ -4,7 +4,11 @@
 //
 
 #import <UIKit/UIKit.h>
+#ifdef SWIFT_PACKAGE
+#import "DMNamespace.h"
+#else
 #import <FluentDarkModeKit/DMNamespace.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/DarkModeCore/UIImage+DarkModeKit.h
+++ b/Sources/DarkModeCore/UIImage+DarkModeKit.h
@@ -4,7 +4,11 @@
 //
 
 #import <UIKit/UIKit.h>
+#ifdef SWIFT_PACKAGE
+#import "DMNamespace.h"
+#else
 #import <FluentDarkModeKit/DMNamespace.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/DarkModeCore/include/DarkModeCore.h
+++ b/Sources/DarkModeCore/include/DarkModeCore.h
@@ -1,4 +1,12 @@
+#ifndef SWIFT_PACKAGE
+#define SWIFT_PACKAGE
+#endif
+
 #import "../DMDynamicColor.h"
 #import "../DMDynamicImage.h"
+#import "../DMNamespace.h"
 #import "../DMTraitCollection.h"
 #import "../NSObject+DarkModeKit.h"
+#import "../UIColor+DarkModeKit.h"
+#import "../UIImage+DarkModeKit.h"
+#import "../UIView+DarkModeKit.h"

--- a/Sources/FluentDarkModeKit/DarkModeManager.swift
+++ b/Sources/FluentDarkModeKit/DarkModeManager.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 #if SWIFT_PACKAGE
-import DarkModeCore
+@_exported import DarkModeCore
 #endif
 
 public final class DarkModeManager: NSObject {

--- a/Sources/FluentDarkModeKit/DarkModeManager.swift
+++ b/Sources/FluentDarkModeKit/DarkModeManager.swift
@@ -4,6 +4,9 @@
 //
 
 import UIKit
+#if SWIFT_PACKAGE
+import DarkModeCore
+#endif
 
 public final class DarkModeManager: NSObject {
   public static func setup() {

--- a/Sources/FluentDarkModeKit/Extensions/UIApplication+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIApplication+DarkModeKit.swift
@@ -4,6 +4,9 @@
 //
 
 import UIKit
+#if SWIFT_PACKAGE
+import DarkModeCore
+#endif
 
 extension UIApplication: DMTraitEnvironment {
   open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {

--- a/Sources/FluentDarkModeKit/Extensions/UIApplication+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIApplication+DarkModeKit.swift
@@ -3,11 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import UIKit
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIApplication: DMTraitEnvironment {
   open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     windows.forEach { $0.dmTraitCollectionDidChange(previousTraitCollection) }

--- a/Sources/FluentDarkModeKit/Extensions/UIButton+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIButton+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIButton {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIImageView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIImageView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIImageView {
 
   private struct Constants {

--- a/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UILabel {
   private enum Constants {
     static var currentThemeKey = "currentThemeKey"

--- a/Sources/FluentDarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UINavigationBar {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIPageControl {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIProgressView {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIScrollView {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UISlider+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UISlider+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UISlider {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UITabBar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITabBar+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UITabBar {
   override open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     super.dmTraitCollectionDidChange(previousTraitCollection)

--- a/Sources/FluentDarkModeKit/Extensions/UITableView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITableView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UITableView {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UITextField+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITextField+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UITextField {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UITextView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITextView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UITextView {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIToolbar {
   override func dm_updateDynamicColors() {
     super.dm_updateDynamicColors()

--- a/Sources/FluentDarkModeKit/Extensions/UIView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIView+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIView: DMTraitEnvironment {
   open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     subviews.forEach { $0.dmTraitCollectionDidChange(previousTraitCollection) }

--- a/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIViewController: DMTraitEnvironment {
   open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     setNeedsStatusBarAppearanceUpdate()

--- a/Sources/FluentDarkModeKit/Extensions/UIWindow+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIWindow+DarkModeKit.swift
@@ -3,11 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import UIKit
-#if SWIFT_PACKAGE
-import DarkModeCore
-#endif
-
 extension UIWindow {
   override open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     super.dmTraitCollectionDidChange(previousTraitCollection)

--- a/Sources/FluentDarkModeKit/Extensions/UIWindow+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIWindow+DarkModeKit.swift
@@ -4,6 +4,9 @@
 //
 
 import UIKit
+#if SWIFT_PACKAGE
+import DarkModeCore
+#endif
 
 extension UIWindow {
   override open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {


### PR DESCRIPTION
Importing via SPM

For Objective-C projects:
1, All the public headers need to be referenced in the folder called "include" to be available to projects that use them
2. They do not have a framework structure to be included/imported with <>

Closes #65 