### PR TITLE
Adopt theme in newly created windows automatically

### DIFF
--- a/FluentDarkModeKit.xcodeproj/project.pbxproj
+++ b/FluentDarkModeKit.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		8CDA62A52366DAA9004895B5 /* DMDynamicColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CDA628B2366DAA9004895B5 /* DMDynamicColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8CE066CF239E5582002CE16D /* UIColor+DarkModeKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CC8D86C2398E4EC0043276A /* UIColor+DarkModeKit.m */; };
 		8CE066D0239E5586002CE16D /* UIImage+DarkModeKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CC8D8722398E7A30043276A /* UIImage+DarkModeKit.m */; };
+		EA2EA50024A1CBF2001AE312 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2EA4FE24A1CAD5001AE312 /* SceneDelegate.swift */; };
 		EA7316F1248F5055009AE037 /* UILabelVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7316EF248F5050009AE037 /* UILabelVC.swift */; };
 /* End PBXBuildFile section */
 
@@ -146,6 +147,7 @@
 		8CDA62892366DAA9004895B5 /* DMDynamicImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DMDynamicImage.m; sourceTree = "<group>"; };
 		8CDA628A2366DAA9004895B5 /* DarkModeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarkModeManager.swift; sourceTree = "<group>"; };
 		8CDA628B2366DAA9004895B5 /* DMDynamicColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DMDynamicColor.h; sourceTree = "<group>"; };
+		EA2EA4FE24A1CAD5001AE312 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		EA7316EF248F5050009AE037 /* UILabelVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelVC.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -278,6 +280,7 @@
 			isa = PBXGroup;
 			children = (
 				8CAFD9D423715FAA001A63B8 /* AppDelegate.swift */,
+				EA2EA4FE24A1CAD5001AE312 /* SceneDelegate.swift */,
 				8CAFD9EC2371606D001A63B8 /* NavigationController.swift */,
 				8CAFD9D823715FAA001A63B8 /* ViewController.swift */,
 				8C7B250223A22034002E2558 /* MainViewController.swift */,
@@ -575,6 +578,7 @@
 				8C63F64323A36B2700D93CF4 /* UIButtonVC.swift in Sources */,
 				EA7316F1248F5055009AE037 /* UILabelVC.swift in Sources */,
 				8CAFD9ED2371606D001A63B8 /* NavigationController.swift in Sources */,
+				EA2EA50024A1CBF2001AE312 /* SceneDelegate.swift in Sources */,
 				8CAFD9D523715FAA001A63B8 /* AppDelegate.swift in Sources */,
 				8C63F64623A374D300D93CF4 /* UIPageControlVC.swift in Sources */,
 				8C7B250423A22060002E2558 /* MainViewController.swift in Sources */,

--- a/Sources/FluentDarkModeKitExample/AppDelegate.swift
+++ b/Sources/FluentDarkModeKitExample/AppDelegate.swift
@@ -17,8 +17,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     DarkModeManager.register(with: application)
 
-    window = UIWindow()
-    window?.rootViewController = {
+    window = AppDelegate.spawnNewWindow()
+    window?.makeKeyAndVisible()
+
+    return true
+  }
+
+  class func spawnNewWindow() -> UIWindow {
+    let window = UIWindow()
+    window.rootViewController = {
       let tabBarController = UITabBarController()
       tabBarController.viewControllers = [
         NavigationController(rootViewController: MainViewController()),
@@ -26,8 +33,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
       ]
       return tabBarController
     }()
-    window?.makeKeyAndVisible()
-
-    return true
+    return window
   }
 }

--- a/Sources/FluentDarkModeKitExample/AppDelegate.swift
+++ b/Sources/FluentDarkModeKitExample/AppDelegate.swift
@@ -17,22 +17,48 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     DarkModeManager.register(with: application)
 
-    window = AppDelegate.spawnNewWindow()
+    if #available(iOS 13.0, *) {
+      return true
+    }
+
+    window = AppDelegate.createNewWindow()
     window?.makeKeyAndVisible()
 
     return true
   }
 
-  class func spawnNewWindow() -> UIWindow {
+  class func createNewWindow(with window: UIWindow) -> UIWindow {
+    guard #available(iOS 13.0, *), let scene = window.windowScene else {
+      return createNewWindow()
+    }
+    return createNewWindow(with: scene)
+  }
+
+  class func createNewWindow() -> UIWindow {
     let window = UIWindow()
-    window.rootViewController = {
-      let tabBarController = UITabBarController()
-      tabBarController.viewControllers = [
-        NavigationController(rootViewController: MainViewController()),
-        NavigationController(rootViewController: ViewController()),
-      ]
-      return tabBarController
-    }()
+    window.rootViewController = spawnNewViewController()
     return window
+  }
+
+  @available(iOS 13.0, *)
+  class func createNewWindow(with windowScene: UIWindowScene) -> UIWindow {
+    let window = UIWindow(windowScene: windowScene)
+    window.rootViewController = spawnNewViewController()
+    return window
+  }
+
+  private class func spawnNewViewController() -> UIViewController {
+    let tabBarController = UITabBarController()
+    tabBarController.viewControllers = [
+      NavigationController(rootViewController: MainViewController()),
+      NavigationController(rootViewController: ViewController()),
+    ]
+    return tabBarController
+  }
+
+  // MARK: UISceneSession Lifecycle
+  @available(iOS 13.0, *)
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+      return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
 }

--- a/Sources/FluentDarkModeKitExample/AppDelegate.swift
+++ b/Sources/FluentDarkModeKitExample/AppDelegate.swift
@@ -27,27 +27,27 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     return true
   }
 
-  class func createNewWindow(with window: UIWindow) -> UIWindow {
+  static func createNewWindow(with window: UIWindow) -> UIWindow {
     guard #available(iOS 13.0, *), let scene = window.windowScene else {
       return createNewWindow()
     }
     return createNewWindow(with: scene)
   }
 
-  class func createNewWindow() -> UIWindow {
+  static func createNewWindow() -> UIWindow {
     let window = UIWindow()
     window.rootViewController = spawnNewViewController()
     return window
   }
 
   @available(iOS 13.0, *)
-  class func createNewWindow(with windowScene: UIWindowScene) -> UIWindow {
+  static func createNewWindow(with windowScene: UIWindowScene) -> UIWindow {
     let window = UIWindow(windowScene: windowScene)
     window.rootViewController = spawnNewViewController()
     return window
   }
 
-  private class func spawnNewViewController() -> UIViewController {
+  private static func spawnNewViewController() -> UIViewController {
     let tabBarController = UITabBarController()
     tabBarController.viewControllers = [
       NavigationController(rootViewController: MainViewController()),

--- a/Sources/FluentDarkModeKitExample/Info.plist
+++ b/Sources/FluentDarkModeKitExample/Info.plist
@@ -20,6 +20,27 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>window</string>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Sources/FluentDarkModeKitExample/MainViewController.swift
+++ b/Sources/FluentDarkModeKitExample/MainViewController.swift
@@ -38,16 +38,33 @@ final class MainViewController: ViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    navigationItem.leftBarButtonItem = UIBarButtonItem(
-      title: "Spawn",
-      style: .plain,
-      target: self,
-      action: #selector(spawnNewWindow)
-    )
+    navigationItem.leftBarButtonItems = [
+      UIBarButtonItem(
+        title: "Replace",
+        style: .plain,
+        target: self,
+        action: #selector(replaceNewWindow)
+      ),
+      UIBarButtonItem(
+        title: "Spawn",
+        style: .plain,
+        target: self,
+        action: #selector(spawnNewWindow)
+      )
+    ]
+  }
+
+  @objc private func replaceNewWindow() {
+    let window = AppDelegate.createNewWindow(with: view.window!)
+    window.makeKeyAndVisible()
+    (UIApplication.shared.delegate as? AppDelegate)?.window = window
   }
 
   @objc private func spawnNewWindow() {
-    AppDelegate.spawnNewWindow().makeKeyAndVisible()
+    guard #available(iOS 13.0, *) else { return }
+
+    let userActivity = NSUserActivity(activityType: "window")
+    UIApplication.shared.requestSceneSessionActivation(nil, userActivity: userActivity, options: nil, errorHandler: nil)
   }
 }
 

--- a/Sources/FluentDarkModeKitExample/MainViewController.swift
+++ b/Sources/FluentDarkModeKitExample/MainViewController.swift
@@ -6,6 +6,8 @@
 import UIKit
 
 final class MainViewController: ViewController {
+  private static var windowCount = 0
+
   struct Row {
     var name: String
     var vcType: UIViewController.Type
@@ -28,6 +30,24 @@ final class MainViewController: ViewController {
 
   override func loadView() {
     view = tableView
+
+    title = "\(MainViewController.windowCount)"
+    MainViewController.windowCount += 1
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      title: "Spawn",
+      style: .plain,
+      target: self,
+      action: #selector(spawnNewWindow)
+    )
+  }
+
+  @objc private func spawnNewWindow() {
+    AppDelegate.spawnNewWindow().makeKeyAndVisible()
   }
 }
 

--- a/Sources/FluentDarkModeKitExample/SceneDelegate.swift
+++ b/Sources/FluentDarkModeKitExample/SceneDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    window = AppDelegate.createNewWindow(with: windowScene)
+    window?.makeKeyAndVisible()
+  }
+
+}


### PR DESCRIPTION
We observe UIWindowDidBecomeVisibleNotification notification, and apply theme to the window, since it is possible to just create a UIWindow and make it key/visible without using UIScene API.

The example app is also updated with multi-window support on iPad.