### PR TITLE
Add dmTraitCollection to DMTraitEnvironment requirement

### DIFF
--- a/Sources/DarkModeCore/DMTraitCollection.h
+++ b/Sources/DarkModeCore/DMTraitCollection.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSInteger, DMUserInterfaceStyle) {
 
 @protocol DMTraitEnvironment <NSObject>
 
+@property (readonly) DMTraitCollection *dmTraitCollection;
+
 - (void)dmTraitCollectionDidChange:(nullable DMTraitCollection *)previousTraitCollection;
 
 @end

--- a/Sources/DarkModeCore/DMTraitCollection.m
+++ b/Sources/DarkModeCore/DMTraitCollection.m
@@ -262,11 +262,16 @@ static BOOL _isObservingNewWindowAddNotification = NO;
 
 @interface UIScreen (DMTraitEnvironment) <DMTraitEnvironment>
 
-- (void)dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection;
-
 @end
 
 @implementation UIScreen (DMTraitEnvironment)
+
+- (DMTraitCollection *)dmTraitCollection {
+  if (@available(iOS 13.0, *)) {
+    return [DMTraitCollection traitCollectionWithUITraitCollection:self.traitCollection];
+  }
+  return DMTraitCollection.overrideTraitCollection;
+}
 
 - (void)dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection {}
 

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -74,6 +74,14 @@
                            OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
+// MARK: - Trait Collection
+- (DMTraitCollection *)dmTraitCollection {
+  if (@available(iOS 13.0, *)) {
+    return [DMTraitCollection traitCollectionWithUITraitCollection:self.traitCollection];
+  }
+  return DMTraitCollection.overrideTraitCollection;
+}
+
 - (void)dmTraitCollectionDidChange:(DMTraitCollection *)previousTraitCollection {
   if (@available(iOS 13.0, *)) {
     return;
@@ -88,6 +96,7 @@
   [self dm_updateDynamicImages];
 }
 
+// MARK: - Legacy Support
 - (void)dm_updateDynamicColors {
   UIColor *backgroundColor = [self dm_dynamicBackgroundColor];
   if (backgroundColor) {

--- a/Sources/FluentDarkModeKit/Extensions/UITabBar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITabBar+DarkModeKit.swift
@@ -11,12 +11,11 @@ extension UITabBar {
       return
     }
 
-    items?.forEach { $0.dmTraitCollectionDidChange(previousTraitCollection) }
     items?.forEach { $0._updateDynamicImages() }
   }
 }
 
-extension UITabBarItem: DMTraitEnvironment {
+extension UITabBarItem {
 
   private struct Constants {
     static var UIImageKey = "UIImageKey"
@@ -72,10 +71,6 @@ extension UITabBarItem: DMTraitEnvironment {
       oldIMP(self, selector, image)
     } as @convention(block) (UITabBarItem, UIImage?) -> Void), method_getTypeEncoding(method))
   }()
-
-  open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
-    // For subclasses to override
-  }
 
   fileprivate func _updateDynamicImages() {
     if let dynamicImage = dm_dynamicImage {

--- a/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
@@ -4,7 +4,7 @@
 //
 
 extension UIViewController: DMTraitEnvironment {
-  public var dmTraitCollection: DMTraitCollection {
+  open var dmTraitCollection: DMTraitCollection {
     if #available(iOS 13.0, *) {
       return DMTraitCollection(uiTraitCollection: traitCollection)
     }

--- a/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIViewController+DarkModeKit.swift
@@ -4,6 +4,13 @@
 //
 
 extension UIViewController: DMTraitEnvironment {
+  public var dmTraitCollection: DMTraitCollection {
+    if #available(iOS 13.0, *) {
+      return DMTraitCollection(uiTraitCollection: traitCollection)
+    }
+    return DMTraitCollection.override
+  }
+
   open func dmTraitCollectionDidChange(_ previousTraitCollection: DMTraitCollection?) {
     if #available(iOS 13.0, *) {
       return

--- a/Tests/FluentDarkModeKitUITests/DarkModeKitUITests.swift
+++ b/Tests/FluentDarkModeKitUITests/DarkModeKitUITests.swift
@@ -17,30 +17,34 @@ final class DarkModeKitUITests: XCTestCase {
   }
 
   func testUIView() {
-    _test("UIView")
+    _test(UIView.self)
   }
 
   func testUIActivityIndicatorView() {
-    _test("UIActivityIndicatorView")
+    _test(UIActivityIndicatorView.self)
   }
 
   func testUIButton() {
-    _test("UIButton")
+    _test(UIButton.self)
   }
 
   func testUIPageControl() {
-    _test("UIPageControl")
+    _test(UIPageControl.self)
   }
 
   func testUILabel() {
-    _test("UILabel")
+    _test(UILabel.self)
   }
 
   func testUIImageView() {
-    _test("UIImageView")
+    _test(UIImageView.self)
   }
 
-  func _test(_ className: String) {
+  func _test(_ `class`: UIView.Type) {
+    _test(by: NSStringFromClass(`class`))
+  }
+
+  func _test(by itemName: String) {
     let app = XCUIApplication()
     let navigationBarIdentifier = "0" // Current window index is used as navigation bar title
     let refreshButtonIdentifier = "Refresh"
@@ -50,7 +54,7 @@ final class DarkModeKitUITests: XCTestCase {
     refreshButton.tap() // light mode
     refreshButton.tap() // dark mode
 
-    let uiviewStaticText = app.tables.staticTexts[className]
+    let uiviewStaticText = app.tables.staticTexts[itemName]
     uiviewStaticText.tap()
 
     sleep(1)


### PR DESCRIPTION
Implementation of https://github.com/microsoft/FluentDarkModeKit/issues/80#issuecomment-652780286

so we have a single place to retrieve the desired theme of a UIView(Controller) (on iOS 12- returns only the overridden theme, on iOS 13+,  the correct theme retrieved from UIKit's traitCollection for the view(controller))

Also removed UITabBarItem's conformance to DMTraitEnvironment since `_updateDynamicImages ` is already called directly and the `dmTraitCollectionDidChange(_:)` method now does nothing.