### PR TITLE
Add theme change handler

### DIFF
--- a/Sources/DarkModeCore/DMEnvironmentConfiguration.h
+++ b/Sources/DarkModeCore/DMEnvironmentConfiguration.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DMEnvironmentConfiguration : NSObject
 
 @property (nonatomic) BOOL useImageAsset; // Defaults to NO
+@property (nullable, nonatomic) void (^themeChangeHandler)(void); // Defaults to nil
 
 - (instancetype)init;
 

--- a/Sources/DarkModeCore/DMEnvironmentConfiguration.m
+++ b/Sources/DarkModeCore/DMEnvironmentConfiguration.m
@@ -11,6 +11,7 @@
   self = [super init];
   if (self) {
     _useImageAsset = NO;
+    _themeChangeHandler = nil;
   }
   return self;
 }

--- a/Sources/DarkModeCore/DMTraitCollection.h
+++ b/Sources/DarkModeCore/DMTraitCollection.h
@@ -51,10 +51,4 @@ typedef NS_ENUM(NSInteger, DMUserInterfaceStyle) {
 
 @end
 
-@interface NSObject (DMTraitEnvironment)
-
-+ (void)swizzleTraitCollectionDidChangeToDMTraitCollectionDidChange API_AVAILABLE(ios(13.0));
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Sources/DarkModeCore/DMTraitCollection.m
+++ b/Sources/DarkModeCore/DMTraitCollection.m
@@ -10,6 +10,12 @@
 
 @import ObjectiveC;
 
+@interface NSObject (DMTraitEnvironment)
+
++ (void)swizzleTraitCollectionDidChangeToDMTraitCollectionDidChange API_AVAILABLE(ios(13.0));
+
+@end
+
 @implementation NSObject (DMTraitEnvironment)
 
 + (void)swizzleTraitCollectionDidChangeToDMTraitCollectionDidChange {
@@ -49,6 +55,7 @@
 
 static DMTraitCollection *_overrideTraitCollection = nil; // This is set manually in setOverrideTraitCollection:animated
 static void (^_userInterfaceStyleChangeHandler)(DMTraitCollection *, BOOL) = nil;
+static void (^_themeChangeHandler)(void) = nil;
 static BOOL _isObservingNewWindowAddNotification = NO;
 
 + (DMTraitCollection *)currentTraitCollection {
@@ -195,6 +202,9 @@ static BOOL _isObservingNewWindowAddNotification = NO;
       return;
 
     [weakSelf updateUIWithViews:strongApp.windows viewControllers:nil traitCollection:traitCollection animated:animated];
+
+    if (_themeChangeHandler)
+      _themeChangeHandler();
   };
 
   [self observeNewWindowNotificationIfNeeded];
@@ -212,6 +222,9 @@ static BOOL _isObservingNewWindowAddNotification = NO;
       return;
 
     [weakSelf updateUIWithViews:nil viewControllers:[NSArray arrayWithObject:strongVc] traitCollection:traitCollection animated:animated];
+
+    if (_themeChangeHandler)
+      _themeChangeHandler();
   };
 
   if (syncImmediately)
@@ -275,6 +288,8 @@ static BOOL _isObservingNewWindowAddNotification = NO;
       [UIView dm_swizzleSetBackgroundColor];
       [UIImage dm_swizzleIsEqual];
     }
+
+    _themeChangeHandler = configuration.themeChangeHandler;
   });
 }
 

--- a/Sources/DarkModeCore/include/DarkModeCore.h
+++ b/Sources/DarkModeCore/include/DarkModeCore.h
@@ -4,7 +4,7 @@
 
 #import "../DMDynamicColor.h"
 #import "../DMDynamicImage.h"
-#import "../DMEnvironmentConfiguration"
+#import "../DMEnvironmentConfiguration.h"
 #import "../DMNamespace.h"
 #import "../DMTraitCollection.h"
 #import "../UIColor+DarkModeKit.h"

--- a/Sources/FluentDarkModeKit/DarkModeManager.swift
+++ b/Sources/FluentDarkModeKit/DarkModeManager.swift
@@ -11,21 +11,24 @@ import UIKit
 public final class DarkModeManager: NSObject {
   private static var swizzlingConfigured = false
 
-  public class func register(with configuration: DMEnvironmentConfiguration, for application: UIApplication, syncImmediately: Bool = false, animated: Bool = false) {
+  public static func setup(with configuration: DMEnvironmentConfiguration) {
     commonSetup(with: configuration)
+  }
+
+  public static func register(with application: UIApplication, syncImmediately: Bool = false, animated: Bool = false) {
     DMTraitCollection.register(with: application, syncImmediately: syncImmediately, animated: animated)
   }
 
-  public class func register(with configuration: DMEnvironmentConfiguration, for viewController: UIViewController, syncImmediately: Bool = false, animated: Bool = false) {
-    commonSetup(with: configuration)
+  @available(iOSApplicationExtension 11.0, *)
+  public static func register(with viewController: UIViewController, syncImmediately: Bool = false, animated: Bool = false) {
     DMTraitCollection.register(with: viewController, syncImmediately: syncImmediately, animated: animated)
   }
 
-  public class func unregister() {
+  public static func unregister() {
     DMTraitCollection.unregister()
   }
 
-  private class func commonSetup(with configuration: DMEnvironmentConfiguration) {
+  private static func commonSetup(with configuration: DMEnvironmentConfiguration) {
     guard !swizzlingConfigured else {
       return
     }

--- a/Sources/FluentDarkModeKitExample/AppDelegate.swift
+++ b/Sources/FluentDarkModeKitExample/AppDelegate.swift
@@ -16,7 +16,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
   ) -> Bool {
 
     let configuration = DMEnvironmentConfiguration()
-    DarkModeManager.register(with: configuration, for: application)
+    configuration.themeChangeHandler = {
+      print("theme changed")
+    }
+    DarkModeManager.setup(with: configuration)
+    DarkModeManager.register(with: application)
 
     if #available(iOS 13.0, *) {
       return true

--- a/Tests/FluentDarkModeKitTests/DarkModeKitTests.swift
+++ b/Tests/FluentDarkModeKitTests/DarkModeKitTests.swift
@@ -9,7 +9,8 @@ import XCTest
 final class DarkModeKitTests: XCTestCase {
   func testSetBackgroundColorSwizzling() {
     UIWindow.appearance().backgroundColor = .white
-    DarkModeManager.register(with: DMEnvironmentConfiguration(), for: .shared)
+    DarkModeManager.setup(with: DMEnvironmentConfiguration())
+    DarkModeManager.register(with: .shared)
     _ = UIWindow()
   }
 


### PR DESCRIPTION
When theme changes, invoke the block in configuration

Adding this so we don't have to swizzle UIScreen's traitCollectionDidChange or subclass UIWindow to observe change, needed in our project.

Breaking down the original register to setup (can only be called once) & register