### PR TITLE
Fix crash for CGColor related property on view called with color with `withAlphaComponent`

### DIFF
--- a/Sources/DarkModeCore/DMDynamicColor.m
+++ b/Sources/DarkModeCore/DMDynamicColor.m
@@ -37,6 +37,10 @@
   }];
 }
 
+- (CGColorRef)CGColor {
+  return [[self resolvedColor] CGColor];
+}
+
 // MARK: Methods that do not need forwarding
 
 - (UIColor *)lightColor {


### PR DESCRIPTION
When setting a view's background color with `withAlphaComponent` with an alpha value other than 0.5, for example `view.backgroundColor = UIColor(.dm, light: .white, dark: .black).withAlphaComponent(0.4)`, it would crash with:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/17924287/92582229-45b11880-f2c3-11ea-9b99-fe801398438e.png">

it's weird that it would not crash with
view.backgroundColor = UIColor(.dm, light: .white, dark: .black).withAlphaComponent(**0.5**)
though

To solve this, we bridge CGColor call directly, instead of relying on message forwarding