### PR TITLE
Making project ready with minimum deployment target >= 13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -9,10 +15,7 @@ jobs:
 
     steps:
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_11.4.1.app
-
-      - name: Install SwiftLint
-        run: brew install swiftlint
+        run: sudo xcode-select -s /Applications/Xcode_12.4.app
 
       - uses: actions/checkout@v1
 

--- a/Sources/DarkModeCore/UIView+DarkModeKit.m
+++ b/Sources/DarkModeCore/UIView+DarkModeKit.m
@@ -29,8 +29,10 @@
   }];
   [self setNeedsLayout];
   [self setNeedsDisplay];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
   [self dm_updateDynamicColors];
   [self dm_updateDynamicImages];
+#endif
 }
 
 // MARK: - Legacy Support

--- a/Sources/FluentDarkModeKit/Extensions/UIButton+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIButton+DarkModeKit.swift
@@ -10,12 +10,13 @@ extension UIButton {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    [UIControl.State.normal, .highlighted, .disabled, .selected, .focused].forEach { state in
-      if let color = titleColor(for: state)?.copy() as? DynamicColor {
-        setTitleColor(color, for: state)
+      [UIControl.State.normal, .highlighted, .disabled, .selected, .focused].forEach { state in
+        if let color = titleColor(for: state)?.copy() as? DynamicColor {
+          setTitleColor(color, for: state)
+        }
       }
     }
   }

--- a/Sources/FluentDarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UINavigationBar+DarkModeKit.swift
@@ -10,11 +10,12 @@ extension UINavigationBar {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {
-      barTintColor = dynamicBarTintColor
+      if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {
+        barTintColor = dynamicBarTintColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIPageControl+DarkModeKit.swift
@@ -10,14 +10,15 @@ extension UIPageControl {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicPageIndicatorTintColor = pageIndicatorTintColor?.copy() as? DynamicColor {
-      pageIndicatorTintColor = dynamicPageIndicatorTintColor
-    }
-    if let dynamicCurrentPageIndicatorTintColor = currentPageIndicatorTintColor?.copy() as? DynamicColor {
-      currentPageIndicatorTintColor = dynamicCurrentPageIndicatorTintColor
+      if let dynamicPageIndicatorTintColor = pageIndicatorTintColor?.copy() as? DynamicColor {
+        pageIndicatorTintColor = dynamicPageIndicatorTintColor
+      }
+      if let dynamicCurrentPageIndicatorTintColor = currentPageIndicatorTintColor?.copy() as? DynamicColor {
+        currentPageIndicatorTintColor = dynamicCurrentPageIndicatorTintColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIProgressView+DarkModeKit.swift
@@ -10,14 +10,15 @@ extension UIProgressView {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicProgressTintColor = progressTintColor?.copy() as? DynamicColor {
-      progressTintColor = dynamicProgressTintColor
-    }
-    if let dynamicTrackTintColor = trackTintColor?.copy() as? DynamicColor {
-      trackTintColor = dynamicTrackTintColor
+      if let dynamicProgressTintColor = progressTintColor?.copy() as? DynamicColor {
+        progressTintColor = dynamicProgressTintColor
+      }
+      if let dynamicTrackTintColor = trackTintColor?.copy() as? DynamicColor {
+        trackTintColor = dynamicTrackTintColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIScrollView+DarkModeKit.swift
@@ -10,16 +10,17 @@ extension UIScrollView {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    indicatorStyle = {
-      if DMTraitCollection.override.userInterfaceStyle == .dark {
-        return .white
-      }
-      else {
-        return .default
-      }
-    }()
+      indicatorStyle = {
+        if DMTraitCollection.override.userInterfaceStyle == .dark {
+          return .white
+        }
+        else {
+          return .default
+        }
+      }()
+    }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UISlider+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UISlider+DarkModeKit.swift
@@ -10,14 +10,15 @@ extension UISlider {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicMinimumTrackTintColor = minimumTrackTintColor?.copy() as? DynamicColor {
-      minimumTrackTintColor = dynamicMinimumTrackTintColor
-    }
-    if let dynamicMaximumTrackTintColor = maximumTrackTintColor?.copy() as? DynamicColor {
-      maximumTrackTintColor = dynamicMaximumTrackTintColor
+      if let dynamicMinimumTrackTintColor = minimumTrackTintColor?.copy() as? DynamicColor {
+        minimumTrackTintColor = dynamicMinimumTrackTintColor
+      }
+      if let dynamicMaximumTrackTintColor = maximumTrackTintColor?.copy() as? DynamicColor {
+        maximumTrackTintColor = dynamicMaximumTrackTintColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UITableView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITableView+DarkModeKit.swift
@@ -10,14 +10,15 @@ extension UITableView {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicSectionIndexColor = sectionIndexColor?.copy() as? DynamicColor {
-      sectionIndexColor = dynamicSectionIndexColor
-    }
-    if let dynamicSeparatorColor = separatorColor?.copy() as? DynamicColor {
-      separatorColor = dynamicSeparatorColor
+      if let dynamicSectionIndexColor = sectionIndexColor?.copy() as? DynamicColor {
+        sectionIndexColor = dynamicSectionIndexColor
+      }
+      if let dynamicSeparatorColor = separatorColor?.copy() as? DynamicColor {
+        separatorColor = dynamicSeparatorColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UITextField+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITextField+DarkModeKit.swift
@@ -10,21 +10,22 @@ extension UITextField {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
+      if let dynamicTextColor = textColor?.copy() as? DynamicColor {
+        textColor = dynamicTextColor
+      }
 
-    if let dynamicTextColor = textColor?.copy() as? DynamicColor {
-      textColor = dynamicTextColor
+      keyboardAppearance = {
+        if DMTraitCollection.override.userInterfaceStyle == .dark {
+          return .dark
+        }
+        else {
+          return .default
+        }
+      }()
     }
-
-    keyboardAppearance = {
-      if DMTraitCollection.override.userInterfaceStyle == .dark {
-        return .dark
-      }
-      else {
-        return .default
-      }
-    }()
   }
 }
 

--- a/Sources/FluentDarkModeKit/Extensions/UITextView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UITextView+DarkModeKit.swift
@@ -10,16 +10,17 @@ extension UITextView {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    keyboardAppearance = {
-      if DMTraitCollection.override.userInterfaceStyle == .dark {
-        return .dark
-      }
-      else {
-        return .default
-      }
-    }()
+      keyboardAppearance = {
+        if DMTraitCollection.override.userInterfaceStyle == .dark {
+          return .dark
+        }
+        else {
+          return .default
+        }
+      }()
+    }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIToolbar+DarkModeKit.swift
@@ -10,11 +10,12 @@ extension UIToolbar {
     if #available(iOS 13.0, *) {
       return
     }
+    else {
+      dm_updateDynamicColors()
 
-    dm_updateDynamicColors()
-
-    if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {
-      barTintColor = dynamicBarTintColor
+      if let dynamicBarTintColor = barTintColor?.copy() as? DynamicColor {
+        barTintColor = dynamicBarTintColor
+      }
     }
   }
 }

--- a/Sources/FluentDarkModeKit/Extensions/UIView+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UIView+DarkModeKit.swift
@@ -5,20 +5,25 @@
 
 extension UIView {
   static let swizzleWillMoveToWindowOnce: Void = {
-    let selector = #selector(willMove(toWindow:))
-    guard let method = class_getInstanceMethod(UIView.self, selector) else {
-      assertionFailure(DarkModeManager.messageForSwizzlingFailed(class: UIView.self, selector: selector))
+    if #available(iOS 13.0, *) {
       return
     }
-
-    let imp = method_getImplementation(method)
-    class_replaceMethod(UIView.self, selector, imp_implementationWithBlock({ (self: UIView, window: UIWindow?) -> Void in
-      let oldIMP = unsafeBitCast(imp, to: (@convention(c) (UIView, Selector, UIWindow?) -> Void).self)
-      oldIMP(self, selector, window)
-      if window != nil {
-        self.dm_updateDynamicColors()
-        self.dm_updateDynamicImages()
+    else {
+      let selector = #selector(willMove(toWindow:))
+      guard let method = class_getInstanceMethod(UIView.self, selector) else {
+        assertionFailure(DarkModeManager.messageForSwizzlingFailed(class: UIView.self, selector: selector))
+        return
       }
-    } as @convention(block) (UIView, UIWindow?) -> Void), method_getTypeEncoding(method))
+
+      let imp = method_getImplementation(method)
+      class_replaceMethod(UIView.self, selector, imp_implementationWithBlock({ (self: UIView, window: UIWindow?) -> Void in
+        let oldIMP = unsafeBitCast(imp, to: (@convention(c) (UIView, Selector, UIWindow?) -> Void).self)
+        oldIMP(self, selector, window)
+        if window != nil {
+          self.dm_updateDynamicColors()
+          self.dm_updateDynamicImages()
+        }
+      } as @convention(block) (UIView, UIWindow?) -> Void), method_getTypeEncoding(method))
+    }
   }()
 }


### PR DESCRIPTION
Ideally when compiling with minimum deployment target >= 13.0, many methods should changed to be no-op, but since a big part of it is implemented in Swift, __IPHONE_OS_VERSION_MIN_REQUIRED cannot come to help with it.