### PR TITLE
Fix missing attributes for UILabel when set attributedText in iOS 11

### DIFF
--- a/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
@@ -73,7 +73,8 @@ extension UILabel {
       }
       if let color = attribute as? DynamicColor {
         updatedAttributedText?.addAttribute(.foregroundColor, value: color.copy(), range: range)
-      } else if let color = textColor as? DynamicColor {
+      }
+      else if let color = textColor as? DynamicColor {
         updatedAttributedText?.addAttribute(.foregroundColor, value: color.copy(), range: range)
       }
     }

--- a/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
+++ b/Sources/FluentDarkModeKit/Extensions/UILabel+DarkModeKit.swift
@@ -68,11 +68,13 @@ extension UILabel {
       let attribute = withUnsafeMutablePointer(to: &range) {
         attributedText.attribute(.foregroundColor, at: index, effectiveRange: $0)
       }
+      if updatedAttributedText == nil {
+        updatedAttributedText = NSMutableAttributedString(attributedString: attributedText)
+      }
       if let color = attribute as? DynamicColor {
-        if updatedAttributedText == nil {
-          updatedAttributedText = NSMutableAttributedString(attributedString: attributedText)
-        }
-        updatedAttributedText?.setAttributes([.foregroundColor: color.copy()], range: range)
+        updatedAttributedText?.addAttribute(.foregroundColor, value: color.copy(), range: range)
+      } else if let color = textColor as? DynamicColor {
+        updatedAttributedText?.addAttribute(.foregroundColor, value: color.copy(), range: range)
       }
     }
 


### PR DESCRIPTION
1) Use addAttribute instead of setAttributes to avoid losing other attributes besides .foregroundColor.
2) If the .foregroundColor attribute is not specified in the NSAttributedString, should be used UILabel textColor. This is standard behavior. Otherwise, the color of the UILabel text does not change.